### PR TITLE
oneOfType wanted an array

### DIFF
--- a/lib/JotFormReact.js
+++ b/lib/JotFormReact.js
@@ -97,7 +97,7 @@ const noop = () => {};
 
 JotFormEmbed.propTypes = {
   formURL: PropTypes.string.isRequired,
-  formID: PropTypes.oneOfType(PropTypes.number, PropTypes.bool),
+  formID: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   autoResize: PropTypes.bool,
   autoFocus: PropTypes.bool,
   heightOffset: PropTypes.number,


### PR DESCRIPTION
This should squash the error: Warning: Invalid argument supplied to oneOfType, expected an instance of array.