### PR TITLE
change case to allowtransparency to fix warnings

### DIFF
--- a/lib/JotFormReact.js
+++ b/lib/JotFormReact.js
@@ -82,7 +82,7 @@ const JotFormEmbed = ({
         ...componentStyles,
         ...style
       }}
-      allowTransparency="true"
+      allowtransparency="true"
       allowFullScreen="true"
       allow="geolocation; microphone; camera"
       frameBorder="0"


### PR DESCRIPTION
changes the case on "allowtransparency" to fix warnings, 

@see: https://github.com/sbayd/jotform-react/issues/8